### PR TITLE
Added forgotten function get_output_from_nn()

### DIFF
--- a/mnist_conv_autoencode.ipynb
+++ b/mnist_conv_autoencode.ipynb
@@ -481,6 +481,18 @@
     }
    ],
    "source": [
+    "def get_output_from_nn(last_layer, X):\n",
+    "    indices = np.arange(128, X.shape[0], 128)\n",
+    "    sys.stdout.flush()\n",
+    "\n",
+    "    # not splitting into batches can cause a memory error\n",
+    "    X_batches = np.split(X, indices)\n",
+    "    out = []\n",
+    "    for count, X_batch in enumerate(X_batches):\n",
+    "        out.append(get_output(last_layer, X_batch).eval())\n",
+    "        sys.stdout.flush()\n",
+    "    return np.vstack(out)\n",
+    "\n",
     "def decode_encoded_input(X):\n",
     "    return get_output_from_nn(final_layer, X)\n",
     "\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ scipy==0.16.0
 six==1.9.0
 tabulate==0.7.5
 Theano==0.7.0
+-e git://github.com/lisa-lab/pylearn2.git@47aafdc1e73ba613f5ebaa6fc63401a1fc468ded#egg=pylearn2-master


### PR DESCRIPTION
Thanks for this awesome example.

When I ran the notebook version, I realized it was missing the `get_output_from_nn()` function. I've borrowed and adapted it from `mnist_conv_autoencode.py`. It works with the latest (development) version of Lasagne, Theano and nolearn.
